### PR TITLE
Add support to delay verification to v0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+default: build
+
 include .bingo/Variables.mk
 
 .PHONY: test

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/test-infra v0.0.0-20231113160404-5e84733188ea
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -124,5 +125,4 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/flags/options.go
+++ b/pkg/flags/options.go
@@ -52,21 +52,24 @@ type Options struct {
 	SelfApprove  bool
 	PRBaseBranch string
 
+	DelayManifestGeneration bool
+
 	flagutil.GitHubOptions
 }
 
 func DefaultOptions() Options {
 	return Options{
-		Mode:         string(Summarize),
-		LogLevel:     logrus.InfoLevel.String(),
-		FetchMode:    string(SSH),
-		DryRun:       true,
-		GithubLogin:  GithubLogin,
-		GithubOrg:    GithubOrg,
-		GitSignoff:   false,
-		Assign:       DefaultPRAssignee,
-		SelfApprove:  false,
-		PRBaseBranch: DefaultBaseBranch,
+		Mode:                    string(Summarize),
+		LogLevel:                logrus.InfoLevel.String(),
+		FetchMode:               string(SSH),
+		DryRun:                  true,
+		GithubLogin:             GithubLogin,
+		GithubOrg:               GithubOrg,
+		GitSignoff:              false,
+		Assign:                  DefaultPRAssignee,
+		SelfApprove:             false,
+		PRBaseBranch:            DefaultBaseBranch,
+		DelayManifestGeneration: false,
 	}
 }
 
@@ -87,6 +90,7 @@ func (o *Options) Bind(fs *flag.FlagSet) {
 	fs.StringVar(&o.Assign, "assign", o.Assign, "The comma-delimited set of github usernames or group names to assign the created pull request to.")
 	fs.BoolVar(&o.SelfApprove, "self-approve", o.SelfApprove, "Self-approve the PR by adding the `approved` and `lgtm` labels. Requires write permissions on the repo.")
 	fs.StringVar(&o.PRBaseBranch, "pr-base-branch", o.PRBaseBranch, "The base branch to use for the pull request.")
+	fs.BoolVar(&o.DelayManifestGeneration, "delay-manifest-generation", o.DelayManifestGeneration, "Delay manifest generation until the end.")
 	o.GitHubOptions.AddFlags(fs)
 	o.GitHubOptions.AllowAnonymous = true
 }


### PR DESCRIPTION
Add an option to delay verification. When multiple commits from different repos come together, there may be conflicts and they are not resolved until everything has been merged. This performs the verification part (i.e. varius `go mod` commands and generating the crds) as part of the last commit.

`-delay-verify`

Also:
* There's also a go.mod change from previous commits
* Update the Makefile to set the default target to `build`
* Stage `go mod vendor` via `git add vendor`