### PR TITLE
v1: don't set GOPROXY=direct

### DIFF
--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -535,7 +535,6 @@ func applyConfig(ctx context.Context, logger *logrus.Entry, org, repo, branch, d
 }
 
 func rewriteGoMod(ctx context.Context, logger *logrus.Entry, dir string, commits map[string]string, commitArgs []string) error {
-	env := append(os.Environ(), "GOPROXY=direct")
 	for name, commit := range commits {
 		if _, err := internal.RunCommand(logger, internal.WithEnv(internal.WithDir(exec.CommandContext(ctx,
 			"go", "mod", "edit", "-replace", fmt.Sprintf("github.com/operator-framework/%s=github.com/openshift/operator-framework-%s@%s", name, name, commit),
@@ -547,7 +546,7 @@ func rewriteGoMod(ctx context.Context, logger *logrus.Entry, dir string, commits
 			exec.CommandContext(ctx, "go", "mod", "vendor"),
 			exec.CommandContext(ctx, "go", "mod", "verify"),
 		} {
-			if _, err := internal.RunCommand(logger, internal.WithEnv(internal.WithDir(cmd, dir), env...)); err != nil {
+			if _, err := internal.RunCommand(logger, internal.WithEnv(internal.WithDir(cmd, dir), os.Environ()...)); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Initially we had used GOPROXY=direct when rewriting the go.mod in order to ensure that our potentially very-new commits we were targeting with the replace directives were fetched correctly. However, when this job is running normally, it won't execute more than once a day and unsetting the GOPROXY settings is only necessary when trying to resolve commits that are O(minutes) new.

We found that using GOPROXY=direct exposed us to missing modules that otherwise would build normally since the proxy servers cache everything exactly for this purpose.