### PR TITLE
Add support to limit the what gets downstreamed in v0 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.8
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/test-infra v0.0.0-20231113160404-5e84733188ea
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/GoogleCloudPlatform/testgrid v0.0.123 h1:S5LE2LjkPsUlyt7blkIgwajiUfgFzv5s17+TkyKDfnI=
 github.com/GoogleCloudPlatform/testgrid v0.0.123/go.mod h1:4Ojwl21NNySkM1rG8hT9K2bugPX9fIrc2hC+GHegLR8=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=


### PR DESCRIPTION

The merge tool always pulls the master branch from all the staging repos.
This is a problem if one of the dependencies has been updated to a version
of something that is incompatible with the base repository, and the base
repository still references an older dependency.

For instance: operator-lifecycle-manager may reference older verisons
of operator-framework/api and operator-framework/operator-registry.

If one of those dependencies is updated to a more recent version of say,
k8s, but OLM hasn't pulled it in, that will cause merge problems.

What should happen is upstream OLM should integrate with those newer
dependencies before they're pulled downstream. Until then, the dependencies
should remain at the versions listed in OLM's depdencies, as specified in
go.mod.

This is done by looking at the latest OLM and seeing what versions
of `api` and `operator-registry` should be referenced.

In addition to the above:

Remove the `go mod` commands run in staging, those commands are not
necessary as upstream should be running them and keeping their go.*
files maintained.

Add logic to handle commits that have been downstreamed after the
tagged version that OLM expects. This is mostly for the transision
period to limiting downstreaming by tag.