### PR TITLE
Fix add of go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This tool is intended to be run as a periodic job with minimal human interaction
 
 The jobs are defined in:
 
-* [infra-periodics.yaml](https://github.com/stevekuznetsov/release/blob/master/ci-operator/jobs/infra-periodics.yaml)
+* [infra-periodics.yaml](https://github.com/openshift/release/blob/master/ci-operator/jobs/infra-periodics.yaml)
 
 ## Manual Merging
 


### PR DESCRIPTION
Add modified go.mod before continuing
* Check explicitly for a `go.mod` error and handle it separately from vendor directory errors.
* The wrong "direction" (`ours` vs `theirs`) was being used for resolution.

Fix URL in README