### PR TITLE
WIP: Stop downstreaming rukpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,19 @@ In the monorepo there are individual Dockerfiles controlling downstream builds f
 
 ## OLMv1
 
-The OLMv1 code is downstreamed into the three separate repositories:
+The OLMv1 code is downstreamed into two separate repositories:
 
 * [operator-framework/catalogd](https://github.com/operator-framework/catalogd) -> [openshift/operator-framework-catalogd](https://github.com/openshift/operator-framework-catalogd)
 * [operator-framework/operator-controller](https://github.com/operator-framework/operator-controller) -> [openshift/operator-framework-operator-controller](https://github.com/openshift/operator-framework-operator-controller) - the main repo
-* [operator-framework/rukpak](https://github.com/operator-framework/rukpak) -> [openshift/operator-framework-rukpak](https://github.com/openshift/operator-framework-rukpak)
 
 The upstream commits are downstreamed as a direct mirror (i.e. commit SHAs remain the same) and then merged into the `main` branch.
 
-However `operator-controller` has dependencies on the `catalogd` and `rukpak` repos, and requires that its `go.mod` is updated to reflect the downstream (openshift) repositories.
-1. Use the upstream `go.mod` file in `operator-controller` to determine which commits of `catalogd` and `rukpak` are to be merged.
+However `operator-controller` has dependencies on the `catalogd` repo, and requires that its `go.mod` is updated to reflect the downstream (openshift) repositories.
+1. Use the upstream `go.mod` file in `operator-controller` to determine which commits of `catalogd` are to be merged.
 2. Synchronize all three upstream repo to their respective downstream repos.
-3. If there are no changes to `catalogd` or `rukpak` (i.e. they've been merged), update the downstream `go.mod` file in `operator-controller` to reference those downstream repos.
+3. If there are no changes to `catalogd` (i.e. they've been merged), update the downstream `go.mod` file in `operator-controller` to reference those downstream repos.
 
-Only if there are no outstanding merges for downstream `catalogd` or `rukpak`, is the `go.mod` file in downstream `operator-controller` updated.
+Only if there are no outstanding merges for downstream `catalogd`, is the `go.mod` file in downstream `operator-controller` updated.
 
 Merging to downstream consists of:
 1. Merging via merge commit upstream `main` branch, this overrides the existing `main` branch via `git merge --stategy=ours`. This keeps the upstream and downstream commits numbered with the same SHA.

--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -36,7 +36,6 @@ func DefaultOptions() Options {
 }
 
 type Options struct {
-	rukpakDir             string
 	operatorControllerDir string
 	catalogDDir           string
 
@@ -46,7 +45,6 @@ type Options struct {
 }
 
 func (o *Options) Bind(fs *flag.FlagSet) {
-	fs.StringVar(&o.rukpakDir, "rukpak-dir", o.rukpakDir, "Directory for rukpak repository.")
 	fs.StringVar(&o.operatorControllerDir, "operator-controller-dir", o.operatorControllerDir, "Directory for operator-controller repository.")
 	fs.StringVar(&o.catalogDDir, "catalogd-dir", o.catalogDDir, "Directory for catalogd repository.")
 	fs.BoolVar(&o.pauseOnCherryPickError, "pause-on-cherry-pick-error", o.pauseOnCherryPickError, "When an error occurs during cherry-pick, pause to allow the user to fix.")
@@ -60,7 +58,6 @@ func (o *Options) Validate() error {
 	}
 
 	for name, val := range map[string]string{
-		"rukpak":              o.rukpakDir,
 		"operator-controller": o.operatorControllerDir,
 		"catalogd":            o.catalogDDir,
 	} {
@@ -80,7 +77,6 @@ type Config struct {
 func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 	directories := map[string]string{
 		"operator-controller": opts.operatorControllerDir,
-		"rukpak":              opts.rukpakDir,
 		"catalogd":            opts.catalogDDir,
 	}
 	commits := map[string]Config{}
@@ -125,7 +121,7 @@ func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 		// downstream repositories have the desired git state already published. Therefore, only if we
 		// found that the repos are up-to-date (they are not in the commits map) can we do the replacing.
 		otherCommits := map[string]string{}
-		for _, repo := range []string{"rukpak", "catalogd"} {
+		for _, repo := range []string{"catalogd"} {
 			if _, ok := commits[repo]; !ok {
 				commit, err := determineDownstreamHead(ctx, logger.WithField("repo", repo), directories[repo], repo, flags.FetchMode(opts.FetchMode))
 				if err != nil {
@@ -268,7 +264,7 @@ func detectNewCommits(ctx context.Context, logger *logrus.Entry, directories map
 		}
 	}
 
-	for _, name := range []string{"rukpak", "catalogd"} {
+	for _, name := range []string{"catalogd"} {
 		module := fmt.Sprintf("github.com/operator-framework/%s", name)
 		rawInfo, err := internal.RunCommand(logger, internal.WithDir(exec.CommandContext(ctx,
 			"go", "list", "-json", "-m", module,


### PR DESCRIPTION
Now that operator-controller doesn't depend on rukpak and we are not shipping it, we should stop downstreaming rukpak. This commit removes all references of rukpak from this repository.