### PR TITLE
Add support to run bingo

### DIFF
--- a/pkg/internal/commands.go
+++ b/pkg/internal/commands.go
@@ -11,6 +11,11 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 )
 
+func RunBingo(ctx context.Context, logger *logrus.Entry) error {
+	_, err := RunCommand(logger, exec.CommandContext(ctx, "bingo", "get"))
+	return err
+}
+
 func SetCommitter(ctx context.Context, logger *logrus.Entry, name string, email string) error {
 	for field, value := range map[string]string{
 		"user.name":  name,

--- a/pkg/v0/cmd.go
+++ b/pkg/v0/cmd.go
@@ -113,6 +113,11 @@ func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 		}
 	}
 
+	// Get the tools for the repository
+	if err := internal.RunBingo(ctx, logger.WithField("phase", "bingo")); err != nil {
+		logger.WithError(err).Fatal("failed to setup tools via bingo")
+	}
+
 	var missingCommits []internal.Commit
 	for _, commit := range commits {
 		commitLogger := logger.WithField("commit", commit.Hash)

--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -106,6 +106,11 @@ func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 		}
 	}
 
+	// Get the tools the repo needs via bingo
+	if err := internal.RunBingo(ctx, logger.WithField("phase", "bingo")); err != nil {
+		logger.WithError(err).Fatal("failed to setup tools via bingo")
+	}
+
 	cherryPickAll := func() {
 		if err := internal.SetCommitter(ctx, logger.WithField("phase", "setup"), opts.GitName, opts.GitEmail); err != nil {
 			logger.WithError(err).Fatal("failed to set committer")

--- a/v0.Dockerfile
+++ b/v0.Dockerfile
@@ -5,6 +5,7 @@ COPY ./cmd/ ./cmd/
 COPY ./pkg/ ./pkg/
 COPY go.mod ./
 RUN go build -o v0 -mod=mod ./cmd/v0/...
+RUN go install -mod=mod github.com/bwplotka/bingo@latest
 
 FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
@@ -12,5 +13,6 @@ RUN dnf install -y git glibc make
 COPY --from=builder /src/github.com/openshift/operator-framework-tooling/v0 /usr/bin/bumper
 COPY --from=builder /usr/lib/golang/bin/go /usr/bin/go
 COPY --from=builder /usr/lib/golang /usr/lib/golang
+COPY --from=builder /go/bin/bingo /usr/bin/bingo
 
 ENTRYPOINT ["bumper"]

--- a/v1.Dockerfile
+++ b/v1.Dockerfile
@@ -5,12 +5,14 @@ COPY ./cmd/ ./cmd/
 COPY ./pkg/ ./pkg/
 COPY go.mod ./
 RUN go build -o v1 -mod=mod ./cmd/v1/...
+RUN go install -mod=mod github.com/bwplotka/bingo@latest
 
 FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 RUN dnf install -y git glibc make
 COPY --from=builder /src/github.com/openshift/operator-framework-tooling/v1 /usr/bin/bumper
 COPY --from=builder /usr/lib/golang/bin/go /usr/bin/go
+COPY --from=builder /go/bin/bingo /usr/bin/bingo
 COPY --from=builder /usr/lib/golang /usr/lib/golang
 
 ENTRYPOINT ["bumper"]


### PR DESCRIPTION
The repos (openshift/operator-framework-olm) need tools managed by bingo to build (in this case, `helm`). Have the bumper run `bingo get` before doing anything.

This requires that bingo be installed in the bumper container.