### PR TITLE
v1: add 'kind/sync' label to sync PRs

### DIFF
--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -25,6 +25,7 @@ const (
 	defaultBranch = "main"
 
 	TideMergeMethodMergeLabel = "tide/merge-method-merge"
+	KindSyncLabel             = "kind/sync"
 )
 
 func DefaultOptions() Options {
@@ -213,6 +214,7 @@ func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 				// determine the commits which need to be carried. But the sync PR itself need to use merge.
 				// By adding this label we instruct tide to merge instead of using the default behaviour.
 				TideMergeMethodMergeLabel,
+				KindSyncLabel,
 			}
 			if opts.SelfApprove {
 				logger.Infof("Self-approving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)


### PR DESCRIPTION
In v1 repos, we need to help automation detect which PRs are for upstream syncs and which PRs are not. To do that we will include a new `kind/sync` label on each PR generated by the `v1` syncer.