### PR TITLE
Remove most of the assumptions from examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,11 +3,6 @@
 These scripts will run the downstreaming tooling to allow you to debug a failing
 downstreaming job.
 
-## Assumptions
-
-This assumes you have this repo located at: `${HOME}/git/openshift/operator-framework-tooling`.
-If you don't, then update the script.
-
 ## How to Run
 
 You should probably run this in an new temporary directory, or a directory dedicated to downstreaming.
@@ -19,7 +14,7 @@ OLMv1:
 ```
 $ mkdir ${HOME}/downstream1
 $ cd ${HOME}/downstream1
-$ ${HOME}/git/openshift/operator-framework/tooling/examples/downstream-v1.sh ${GITHUB_USER}
+$ ${HOME}/path/to/operator-framework-tooling/examples/downstream-v1.sh -u ${GITHUB_USER}
 ```
 
 OLMv0 would be similar.

--- a/examples/downstream-v0.sh
+++ b/examples/downstream-v0.sh
@@ -1,16 +1,44 @@
 #!/bin/bash
-#
-# This script will run a local OLMv0 downstream operation, to allow someone to
-# debug a failure.
-#
-# Assumptions:
-# * The tooling directory is located in ${HOME}/git/openshift/operator-framework-tooling
-# * The v0 executable has been built in there via `make`
-#
-# Call with your github user name, if it's not the same as your current user name.
-#
+set -euo pipefail
 
-GITHUB_USER=${1:-${USER}}
+usage() {
+    echo "This script will run a local OLMv0 downstream operation, to allow someone to"
+    echo "debug a failure."
+    echo ""
+    echo "Usage: $0 [-u github-username] [-a \"-extra-sync args\"] [-d /path/to/the/sync/dir]"
+    echo ""
+    echo "Options:"
+    echo " -u GitHub username. Default: current system user."
+    echo " -a Additional arguments to the syncer."
+    echo " -d Path to the sync dir. Default: current working directory."
+    echo ""
+}
+
+GITHUB_USER=$USER
+SYNC_ARGS=""
+SYNC_DIR=$PWD
+
+# Get the options
+while getopts "hu:a:d:" option; do
+   case $option in
+      u)
+        GITHUB_USER=$OPTARG;;
+      a)
+        SYNC_ARGS=$OPTARG;;
+      d)
+        SYNC_DIR=$OPTARG;;
+      h)
+        usage
+        exit 1;;
+     \?)
+        usage
+        exit 1;;
+   esac
+done
+
+# Get an absolute path of the root of the tooling repo
+# based on the path of this script.
+TOOLS_REPO_DIR=$(dirname "$( cd $(dirname $0) ; pwd)")
 
 # Cleanup from last time
 reset-repo () {
@@ -26,6 +54,7 @@ reset-repo () {
 }
 
 setup-repo() {
+    pushd $SYNC_DIR
     if [ -d $1 ]; then
         echo "Resetting $1"
         (cd $1 && reset-repo)
@@ -34,14 +63,19 @@ setup-repo() {
         git clone git@github.com:openshift/$1.git
         git -C $1 remote add ${GITHUB_USER} git@github.com:${GITHUB_USER}/$1.git
     fi
+    popd
 }
 
 setup-repo operator-framework-olm
 
+make -C $TOOLS_REPO_DIR
+
 set -x
 
-cd operator-framework-olm
-${HOME}/git/openshift/operator-framework-tooling/v0 \
+pushd $SYNC_DIR/operator-framework-olm
+${TOOLS_REPO_DIR}/v0 \
        --mode=synchronize \
        --delay-manifest-generation \
-       --log-level=debug
+       --log-level=debug \
+       ${SYNC_ARGS}
+popd

--- a/examples/downstream-v1.sh
+++ b/examples/downstream-v1.sh
@@ -1,23 +1,51 @@
 #!/bin/bash
-#
-# This script will run a local OLMv1 downstream operation, to allow someone to
-# debug a failure.
-#
-# Assumptions:
-# * The tooling directory is located in ${HOME}/git/openshift/operator-framework-tooling
-# * The v1 executable has been built in there via `make`
-#
-# Call with your github user name, if it's not the same as your current user name.
-#
+set -euo pipefail
 
-GITHUB_USER=${1:-${USER}}
+usage() {
+    echo "This script will run a local OLMv1 downstream operation, to allow someone to"
+    echo "debug a failure."
+    echo ""
+    echo "Usage: $0 [-u github-username] [-a \"-extra-sync args\"] [-d /path/to/the/sync/dir]"
+    echo ""
+    echo "Options:"
+    echo " -u GitHub username. Default: current system user."
+    echo " -a Additional arguments to the syncer."
+    echo " -d Path to the sync dir. Default: current working directory."
+    echo ""
+}
+
+GITHUB_USER=$USER
+SYNC_ARGS=""
+SYNC_DIR=$PWD
+
+# Get the options
+while getopts "hu:a:d:" option; do
+   case $option in
+      u)
+        GITHUB_USER=$OPTARG;;
+      a)
+        SYNC_ARGS=$OPTARG;;
+      d)
+        SYNC_DIR=$OPTARG;;
+      h)
+        usage
+        exit 1;;
+     \?)
+        usage
+        exit 1;;
+   esac
+done
+
+# Get an absolute path of the root of the tooling repo
+# based on the path of this script.
+TOOLS_REPO_DIR=$(dirname "$( cd $(dirname $0) ; pwd)")
 
 # Cleanup from last time
 reset-repo () {
     git reset HEAD --hard
     git checkout main
     git reset origin/main --hard
-    git branch -D synchronize
+    git branch -D synchronize || true # It's ok if it doesnt' exist
     git clean -fdx
     git reflog expire --expire-unreachable=now --all
     git gc --prune=now
@@ -27,6 +55,7 @@ reset-repo () {
 }
 
 setup-repo() {
+    pushd $SYNC_DIR
     if [ -d $1 ]; then
         echo "Resetting $1"
         (cd $1 && reset-repo)
@@ -35,17 +64,23 @@ setup-repo() {
         git clone git@github.com:openshift/$1.git
         git -C $1 remote add ${GITHUB_USER} git@github.com:${GITHUB_USER}/$1.git
     fi
+    popd
 }
 
 setup-repo operator-framework-catalogd
 setup-repo operator-framework-operator-controller
 
-${HOME}/git/openshift/operator-framework-tooling/v1 \
+make -C $TOOLS_REPO_DIR
+
+set -x
+
+${TOOLS_REPO_DIR}/v1  \
        --mode=synchronize \
-       --catalogd-dir=${PWD}/operator-framework-catalogd \
-       --operator-controller-dir=${PWD}/operator-framework-operator-controller \
+       --catalogd-dir=${SYNC_DIR}/operator-framework-catalogd \
+       --operator-controller-dir=${SYNC_DIR}/operator-framework-operator-controller \
        --pause-on-cherry-pick-error \
-       --log-level=debug
+       --log-level=debug \
+       ${SYNC_ARGS}
 
 # Additional option: https://github.com/openshift/operator-framework-tooling/pull/44
 #       --delay-manifest-generation \


### PR DESCRIPTION
Makes a bit easier to run the script because you no longer need to manually run `make` before running the script and you don't have to checkout tooling repo into a specific path.