### PR TITLE
Update approvers and reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,24 +5,21 @@ aliases:
   - kevinrizza
   - oceanc80
   - perdasilva
-  - stevekuznetsov
   - tmshort
   - LalatenduMohanty
 
   operator-framework-reviewers:
   - anik120
   - ankitathomas
+  - azych
   - bentito
+  - camilamacedo86
   - dtfranz
-  - everettraven
   - grokspawn
   - joelanford
   - kevinrizza
   - oceanc80
   - perdasilva
   - rashmigottipati
-  - stevekuznetsov
-  - theishshah
   - tmshort
-  - varshaprasad96
   - LalatenduMohanty


### PR DESCRIPTION
This should also update the release image, such that golang 1.23.4 is used.