### PR TITLE
Add extra vendor for custom-linters

### DIFF
--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -604,7 +604,7 @@ func applyConfig(ctx context.Context, logger *logrus.Entry, org, repo, branch, d
 	}
 
 	extraVendor := map[string][]string{
-		"operator-controller": {"testdata/push", "testdata/registry"},
+		"operator-controller": {"testdata/push", "testdata/registry", "hack/ci/custom-linters/analyzers/testdata"},
 	}
 
 	generatedPatches := []*exec.Cmd{


### PR DESCRIPTION
A custom linter was added upstrem, and it has its own `go.mod` file. So it needs to be vendored when downstreaming occurs.

Add `hack/ci/custom-linters/analyzers/testdata` to the list of directories that need extra vendoring.