### PR TITLE
OPRUN-3741: OLMv0: Use main branch when it's available

### DIFF
--- a/cmd/v0/main.go
+++ b/cmd/v0/main.go
@@ -11,8 +11,11 @@ import (
 )
 
 func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
 	logger := logrus.New()
-	opts := v0.DefaultOptions()
+	opts := v0.DefaultOptions(ctx, logger)
 	opts.Bind(flag.CommandLine)
 	flag.Parse()
 
@@ -22,9 +25,6 @@ func main() {
 
 	logLevel, _ := logrus.ParseLevel(opts.LogLevel)
 	logger.SetLevel(logLevel)
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
 
 	if err := v0.Run(ctx, logger, opts); err != nil {
 		logrus.WithError(err).Fatal("failed to execute")

--- a/examples/downstream-v0.sh
+++ b/examples/downstream-v0.sh
@@ -17,6 +17,7 @@ usage() {
 GITHUB_USER=$USER
 SYNC_ARGS=""
 SYNC_DIR=$PWD
+SYNC_BRANCH=master
 
 # Get the options
 while getopts "hu:a:d:" option; do
@@ -43,8 +44,12 @@ TOOLS_REPO_DIR=$(dirname "$( cd $(dirname $0) ; pwd)")
 # Cleanup from last time
 reset-repo () {
     git reset HEAD --hard
-    git checkout master
-    git reset origin/master --hard
+    # if the main branch exists, use that instead
+    if git show-ref --verify --quiet refs/heads/main; then
+        SYNC_BRANCH=main
+    fi
+    git checkout ${SYNC_BRANCH}
+    git reset origin/${SYNC_BRANCH} --hard
     git clean -fdx
     git reflog expire --expire-unreachable=now --all
     git gc --prune=now

--- a/pkg/flags/options.go
+++ b/pkg/flags/options.go
@@ -30,7 +30,7 @@ const (
 
 	DefaultPRAssignee = "openshift/openshift-team-operator-framework"
 
-	DefaultBaseBranch = "master"
+	DefaultBaseBranch = "main"
 )
 
 type Options struct {

--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -22,8 +22,6 @@ import (
 )
 
 const (
-	defaultBranch = "main"
-
 	TideMergeMethodMergeLabel = "tide/merge-method-merge"
 	KindSyncLabel             = "kind/sync"
 )
@@ -32,7 +30,6 @@ func DefaultOptions() Options {
 	opts := Options{
 		Options: flags.DefaultOptions(),
 	}
-	opts.Options.PRBaseBranch = defaultBranch
 	return opts
 }
 


### PR DESCRIPTION
CRT is renaming downstream branches from master to main. This takes into account the current downstream branch name to use for the PR. Assume "main", but change to "master" for OLMv0 if "main" is not found.

It also updates other uses of "master" to be clear as to the use (i.e. upstream)