### PR TITLE
Add cherry-pick merge strategy

### DIFF
--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -575,7 +575,10 @@ func applyConfig(ctx context.Context, logger *logrus.Entry, org, repo, branch, d
 	for _, commit := range config.Additional {
 		cherryPickCommands := []*exec.Cmd{
 			internal.WithDir(exec.CommandContext(ctx,
-				"git", "cherry-pick", commit.Hash,
+				"git", "cherry-pick",
+				"--strategy=ort",
+				"--strategy-option=ours",
+				commit.Hash,
 			), dir),
 		}
 		goModCommands := []*exec.Cmd{


### PR DESCRIPTION
Update the merge strategy to be `ort`, which is the default, but with the option of `ours`, which will prefer the incoming cherry-pick changes over the existing code. This is only done during the downstream cherry-picks which ought to be safe.

The conflict might come from go.mod or go.sum files that were updated by a prior `go mod tidy` or `go mod vendor` command.

One of the last drop commits is a `go mod tidy` and `go mod vendor` over _all_ the vendored code (basically wherever a `go.mod` is found).