### PR TITLE
NO-ISSUE: Allow users to publish sync PRs from example scripts

### DIFF
--- a/examples/downstream-v0.sh
+++ b/examples/downstream-v0.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 usage() {
     echo "This script will run a local OLMv0 downstream operation, to allow someone to"
-    echo "debug a failure."
+    echo "debug a failure. It will push the resulting branch and create a pull request."
+    echo ""
+    echo "Requires the 'gh' CLI to be authenticated ('gh auth login') before running."
     echo ""
     echo "Usage: $0 [-u github-username] [-a \"-extra-sync args\"] [-d /path/to/the/sync/dir]"
     echo ""
@@ -18,6 +20,8 @@ GITHUB_USER=$USER
 SYNC_ARGS=""
 SYNC_DIR=$PWD
 SYNC_BRANCH=master
+GITHUB_TOKEN_PATH="$(mktemp "${HOME}/.github-token.XXXXXX")"
+trap 'rm -f "$GITHUB_TOKEN_PATH"' EXIT
 
 # Get the options
 while getopts "hu:a:d:" option; do
@@ -75,11 +79,24 @@ setup-repo operator-framework-olm
 
 make -C $TOOLS_REPO_DIR
 
+if ! command -v gh &> /dev/null; then
+    echo "error: 'gh' CLI not found in PATH. Install it and run 'gh auth login' first."
+    exit 1
+fi
+
+# Create the GitHub token file from the gh CLI's stored credentials.
+# Run 'gh auth login' first if you haven't already.
+gh auth token > "${GITHUB_TOKEN_PATH}"
+chmod 600 "${GITHUB_TOKEN_PATH}"
+
 set -x
 
 pushd $SYNC_DIR/operator-framework-olm
 ${TOOLS_REPO_DIR}/v0 \
-       --mode=synchronize \
+       --mode=publish \
+       --dry-run=false \
+       --github-login=${GITHUB_USER} \
+       --github-token-path=${GITHUB_TOKEN_PATH} \
        --delay-manifest-generation \
        --log-level=debug \
        ${SYNC_ARGS}

--- a/examples/downstream-v1.sh
+++ b/examples/downstream-v1.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 usage() {
     echo "This script will run a local OLMv1 downstream operation, to allow someone to"
-    echo "debug a failure."
+    echo "debug a failure. It will push the resulting branch and create a pull request."
+    echo ""
+    echo "Requires the 'gh' CLI to be authenticated ('gh auth login') before running."
     echo ""
     echo "Usage: $0 [-u github-username] [-a \"-extra-sync args\"] [-d /path/to/the/sync/dir]"
     echo ""
@@ -17,6 +19,8 @@ usage() {
 GITHUB_USER=$USER
 SYNC_ARGS=""
 SYNC_DIR=$PWD
+GITHUB_TOKEN_PATH="$(mktemp "${HOME}/.github-token.XXXXXX")"
+trap 'rm -f "$GITHUB_TOKEN_PATH"' EXIT
 
 # Get the options
 while getopts "hu:a:d:" option; do
@@ -71,10 +75,23 @@ setup-repo operator-framework-operator-controller
 
 make -C $TOOLS_REPO_DIR
 
+if ! command -v gh &> /dev/null; then
+    echo "error: 'gh' CLI not found in PATH. Install it and run 'gh auth login' first."
+    exit 1
+fi
+
+# Create the GitHub token file from the gh CLI's stored credentials.
+# Run 'gh auth login' first if you haven't already.
+gh auth token > "${GITHUB_TOKEN_PATH}"
+chmod 600 "${GITHUB_TOKEN_PATH}"
+
 set -x
 
 ${TOOLS_REPO_DIR}/v1  \
-       --mode=synchronize \
+       --mode=publish \
+       --dry-run=false \
+       --github-login=${GITHUB_USER} \
+       --github-token-path=${GITHUB_TOKEN_PATH} \
        --operator-controller-dir=${SYNC_DIR}/operator-framework-operator-controller \
        --pause-on-cherry-pick-error \
        --log-level=debug \

--- a/pkg/flags/options.go
+++ b/pkg/flags/options.go
@@ -28,7 +28,7 @@ const (
 	GithubOrg   = "openshift"
 	GithubLogin = "openshift-bot"
 
-	DefaultPRAssignee = "openshift/openshift-team-operator-framework"
+	DefaultPRAssignee = "openshift/openshift-team-operator-runtime"
 
 	DefaultBaseBranch = "main"
 )
@@ -124,7 +124,6 @@ func (o *Options) Validate() error {
 		if o.Assign == "" {
 			return fmt.Errorf("--assign is mandatory")
 		}
-
 		if err := o.GitHubOptions.Validate(o.DryRun); err != nil {
 			return err
 		}

--- a/pkg/internal/formatting.go
+++ b/pkg/internal/formatting.go
@@ -97,7 +97,7 @@ func GetBody(commits []Commit, assign []string) string {
 	}
 	lines = append(lines, "", "This pull request is expected to merge without any human intervention. If tests are failing here, changes must land upstream to fix any issues so that future downstreaming efforts succeed.", "")
 	for _, who := range assign {
-		lines = append(lines, fmt.Sprintf("/cc @%s", who))
+		lines = append(lines, fmt.Sprintf("/assign @%s", who))
 	}
 
 	body := strings.Join(lines, "\n")
@@ -205,7 +205,7 @@ func GetBodyV1(targetList []Commit, commits []Commit, assign []string, jiraTicke
 	}
 	lines = append(lines, "", "This pull request is expected to merge without any human intervention. If tests are failing here, changes must land upstream to fix any issues so that future downstreaming efforts succeed.", "")
 	for _, who := range assign {
-		lines = append(lines, fmt.Sprintf("/cc @%s", who))
+		lines = append(lines, fmt.Sprintf("/assign @%s", who))
 	}
 
 	body := strings.Join(lines, "\n")

--- a/pkg/v0/cmd.go
+++ b/pkg/v0/cmd.go
@@ -205,7 +205,11 @@ func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 		}
 		if err := bumper.UpdatePullRequestWithLabels(gc, opts.GithubOrg, opts.GithubRepo, title,
 			internal.GetBody(commits, strings.Split(opts.Assign, ",")), opts.GithubLogin+":"+remoteBranch, opts.PRBaseBranch, remoteBranch, true, labelsToAdd, opts.DryRun); err != nil {
-			return fmt.Errorf("PR creation failed.: %w", err)
+			if strings.Contains(err.Error(), "failed to add label") {
+				logger.WithError(err).Warn("PR created but failed to add labels")
+			} else {
+				return fmt.Errorf("PR creation failed.: %w", err)
+			}
 		}
 	}
 	return nil

--- a/pkg/v1/cmd.go
+++ b/pkg/v1/cmd.go
@@ -307,7 +307,11 @@ func Run(ctx context.Context, logger *logrus.Logger, opts Options) error {
 			}
 			if err := bumper.UpdatePullRequestWithLabels(gc, opts.GithubOrg, fork, title, body,
 				opts.GithubLogin+":"+remoteBranch, opts.PRBaseBranch, remoteBranch, true, labelsToAdd, opts.DryRun); err != nil {
-				return fmt.Errorf("PR creation failed.: %w", err)
+				if strings.Contains(err.Error(), "failed to add label") {
+					logger.WithError(err).Warn("PR created but failed to add labels")
+				} else {
+					return fmt.Errorf("PR creation failed.: %w", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Update example scripts to use --mode=publish with GitHub token generation via the gh CLI. Make --assign optional with no default, skip empty /cc entries in PR descriptions, and treat label-addition failures as warnings rather than fatal errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI/scripts now generate and use a temporary GitHub token file, require prior gh authentication, and run publish flows that push branches and open pull requests (no dry-run).

* **Bug Fixes**
  * Default PR assignee updated to a different team.
  * PR body uses assign commands instead of cc.
  * Failures adding labels now log a warning and no longer abort PR creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->