### PR TITLE
OPRUN-4638: Update to golang-1.26 release-4.23

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: ocp
-  tag: rhel-9-golang-1.25-openshift-4.22
+  tag: rhel-9-golang-1.26-openshift-4.23

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/operator-framework-tooling
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/v0.Dockerfile
+++ b/v0.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
 WORKDIR /src/github.com/openshift/operator-framework-tooling
 COPY ./cmd/ ./cmd/
@@ -7,7 +7,7 @@ COPY go.mod ./
 RUN go build -o v0 -mod=mod ./cmd/v0/...
 RUN go install -mod=mod github.com/bwplotka/bingo@v0.9.0
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.23:base-rhel9
 
 RUN dnf install -y git glibc make
 COPY --from=builder /src/github.com/openshift/operator-framework-tooling/v0 /usr/bin/bumper

--- a/v1.Dockerfile
+++ b/v1.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
 WORKDIR /src/github.com/openshift/operator-framework-tooling
 COPY ./cmd/ ./cmd/
@@ -7,7 +7,7 @@ COPY go.mod ./
 RUN go build -o v1 -mod=mod ./cmd/v1/...
 RUN go install -mod=mod github.com/bwplotka/bingo@v0.9.0
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.23:base-rhel9
 
 RUN dnf install -y git glibc make
 COPY --from=builder /src/github.com/openshift/operator-framework-tooling/v1 /usr/bin/bumper


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.26.3.
  * Updated base container images to OpenShift 4.23 and the Go runtime environment to 1.26.
  * Aligned CI builder/root image configuration to use the updated OpenShift/Go image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->